### PR TITLE
feat(errors) mark errors inline with a red underline

### DIFF
--- a/src/components/Playground.vue
+++ b/src/components/Playground.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import MonacoEditor from 'vue-monaco'
-import { editor, Range } from 'monaco-editor'
+import { editor, Range, Position } from 'monaco-editor'
 import * as fengari from 'fengari-web'
 import basic from '@/snippets/basic'
 import Toolbar from '@/components/Toolbar.vue'
@@ -87,6 +87,15 @@ export default Vue.extend({
           const decorations = []
           let d = 0
 
+          if (!this.editorInput) {
+            return
+          }
+
+          const model = this.editorInput.getModel()
+          if (!model) {
+            return
+          }
+
           let i = 1
           while (syntaxErrors.has(i)) {
             const err = syntaxErrors.get(i)
@@ -95,11 +104,15 @@ export default Vue.extend({
             const msg = err.get('msg')
             console.log(msg)
 
-            decorations[d] = {
-              range: new Range(y, x, y, x),
-              options: { inlineClassName: 'syntax-error' }
+            const word = model.getWordAtPosition(new Position(y, x))
+
+            if (word) {
+              decorations[d] = {
+                range: new Range(y, word.startColumn, y, word.endColumn),
+                options: { inlineClassName: 'syntax-error' }
+              }
+              d++
             }
-            d++
 
             i++
           }
@@ -112,11 +125,15 @@ export default Vue.extend({
             const msg = err.get('msg')
             console.log(msg)
 
-            decorations[d] = {
-              range: new Range(y, x, y, x + 1),
-              options: { inlineClassName: 'type-error' }
+            const word = model.getWordAtPosition(new Position(y, x))
+
+            if (word) {
+              decorations[d] = {
+                range: new Range(y, word.startColumn, y, word.endColumn),
+                options: { inlineClassName: 'type-error' }
+              }
+              d++
             }
-            d++
 
             i++
           }


### PR DESCRIPTION
This is an ugly WIP (both the code and the output :laughing: ), but that's as far as I could go for now :)

Tried to make the errors appear inline, IDE-style. Based it on this:

https://microsoft.github.io/monaco-editor/playground.html#interacting-with-the-editor-line-and-inline-decorations

What's done:

- [x] collect errors as separate x, y and message variables usable from the TS side
- [x] reflect the position of the errors as decorations in the editor component
- [x] update those in realtime

What's missing:

- [ ] CSS for nice squiggly IDE-like red underline 
- [ ] extending the underline through the whole token instead of only the first character (is there some Monaco API to get the length of the word at position x,y?)
- [ ] show a tooltip with the error message, like in the Monaco Playground above

I don't plan to pursue these todo items myself as stumbling through TS, Vue and Monaco to get the code to this point was already challenging enough (fun learning experience though!), but hopefully this can be a useful starting point! :grin: 