### PR TITLE
Add monaco-languages's MIT license

### DIFF
--- a/src/teal-monaco-language.ts
+++ b/src/teal-monaco-language.ts
@@ -1,5 +1,16 @@
 /* eslint-disable */
-// Based on https://raw.githubusercontent.com/microsoft/monaco-languages/master/src/lua/lua.ts
+
+/* Based on the Lua syntax from https://github.com/microsoft/monaco-languages, which has the following license:
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
 
 import monaco from "monaco-editor";
 


### PR DESCRIPTION
To comply with [monaco-languages's MIT license](https://github.com/microsoft/monaco-languages/blob/master/LICENSE.md), I added an attribution at the top of `teal-monaco-language.ts`.

(I guess nobody cares about this, but... it's better to be safe than sorry :))