### PR TITLE
fix(quoting) quote user input when feeding into Lua code

### DIFF
--- a/src/components/Playground.vue
+++ b/src/components/Playground.vue
@@ -42,7 +42,7 @@ os = { getenv = function (str) return '' end }
 local tl = require('tl')
 
 local env = tl.init_env(false, true)
-local output, result = tl.gen([[%input%]], env)
+local output, result = tl.gen(%input%, env)
 
 return { output, result.syntax_errors, result.type_errors }
 `
@@ -92,7 +92,7 @@ export default Vue.extend({
             this.output = ''
             return
           }
-          const out: LuaTableJs = fengari.load(tl.replace('%input%', newValue))()
+          const out: LuaTableJs = fengari.load(tl.replace('%input%', JSON.stringify(newValue)))()
           this.loadError = null
           this.output = out.get(1) || this.output
           const syntaxErrors = out.get(2) || null


### PR DESCRIPTION
JSON encoding seems compatible enough so that it produces
a valid Lua string for the purposes of this playground.

I couldn't find a case where I could break out of the sandbox,
which was possible before.

Fixes #3.