### PR TITLE
fix: make os.getenv return nil for unknown vars

### DIFF
--- a/src/components/Playground.vue
+++ b/src/components/Playground.vue
@@ -57,7 +57,13 @@ languages.setLanguageConfiguration('teal', tealMonacoLanguageConfiguration)
 
 const tl = `
 package.path = "${process.env.VUE_APP_TL_PACKAGE_PATH_URL}"
-os = { getenv = function (str) return '' end }
+os = {
+  getenv = function (var)
+    if var == 'TL_PATH' then
+      return ''
+    end
+  end
+}
 local tl = require('tl')
 
 local env = tl.init_env(false, false, true)


### PR DESCRIPTION
The playground is failing because current tl.tl uses os.getenv
to check TL_DEBUG and that fails with an empty string.
The solution is to make os.getenv a bit smarter and return
the empty string only for TL_PATH (to keep current behavior),
and nil for everything else.